### PR TITLE
Update ssh_config: remove second `ForwardX11 no`

### DIFF
--- a/config/ssh/ssh_config
+++ b/config/ssh/ssh_config
@@ -14,5 +14,4 @@ Host *
     ForwardX11 no
     ForwardAgent no
     ServerAliveInterval 60
-    ForwardX11 no
     ControlMaster no


### PR DESCRIPTION
Only use ssh option `ForwardX11 no` once.

Did you mean `ForwardX11Trusted no` ?